### PR TITLE
Event horizon

### DIFF
--- a/jokers/event_horizon.lua
+++ b/jokers/event_horizon.lua
@@ -35,11 +35,14 @@ local function find_highest_played_hands()
     local highest_played_hands = {}
 
     for k, v in pairs(G.GAME.hands) do
-        if v.played == highest_played_count then
-            highest_played_hands[#highest_played_hands+1] = k
-        elseif v.played > highest_played_count then
-            highest_played_count = v.played
-            highest_played_hands = { k }
+        -- Prevent hands like Flush Five being upgraded when not yet unlocked
+        if v.visible or v.played > 0 then
+            if v.played == highest_played_count then
+                highest_played_hands[#highest_played_hands+1] = k
+            elseif v.played > highest_played_count then
+                highest_played_count = v.played
+                highest_played_hands = { k }
+            end
         end
     end
 

--- a/jokers/event_horizon.lua
+++ b/jokers/event_horizon.lua
@@ -30,25 +30,6 @@ local function dissolve_consumables()
     return count
 end
 
-local function find_highest_played_hands()
-    local highest_played_count = 0
-    local highest_played_hands = {}
-
-    for k, v in pairs(G.GAME.hands) do
-        -- Prevent hands like Flush Five being upgraded when not yet unlocked
-        if v.visible or v.played > 0 then
-            if v.played == highest_played_count then
-                highest_played_hands[#highest_played_hands+1] = k
-            elseif v.played > highest_played_count then
-                highest_played_count = v.played
-                highest_played_hands = { k }
-            end
-        end
-    end
-
-    return highest_played_hands
-end
-
 SMODS.Joker {
     key = 'event_horizon',
     loc_txt = {
@@ -79,8 +60,8 @@ SMODS.Joker {
         local dissolved_consumables = dissolve_consumables()
         if dissolved_consumables == 0 then return end
 
-        local highest_played_hands = find_highest_played_hands()
-        local hand_to_upgrade = pseudorandom_element(highest_played_hands, pseudoseed('event_horizon'))
+        -- Defaults to High Card. Seems sensible.
+        local hand_to_upgrade = G.GAME.current_round.most_played_poker_hand
         local levels = dissolved_consumables * card.ability.extra.levels_per_consumable
 
         delay(1)

--- a/jokers/event_horizon.lua
+++ b/jokers/event_horizon.lua
@@ -1,0 +1,72 @@
+local function perform_hand_levelup(hand_type, level_diff)
+    -- Taken from card.lua:1265
+    update_hand_text({
+        sound = 'button',
+        volume = 0.7,
+        pitch = 0.8,
+        delay = 0.3
+    }, {
+        handname = localize(hand_type, 'poker_hands'),
+        chips = G.GAME.hands[hand_type].chips,
+        mult = G.GAME.hands[hand_type].mult,
+        level = G.GAME.hands[hand_type].level
+    })
+    delay(1)
+    level_up_hand(card, hand_type, false, level_diff or 0)
+    update_hand_text({sound = 'button', volume = 0.7, pitch = 1.1, delay = 0}, {mult = 0, chips = 0, handname = '', level = ''})
+end
+
+SMODS.Joker {
+    key = 'event_horizon',
+    loc_txt = {
+        name = 'Event Horizon',
+        text = {
+            'When blind is selected,',
+            'destroy all {C:attention}held consumables{},',
+            'then upgrade level of',
+            'most played {C:attention}poker hand{}',
+            'once {C:attention}per{} destroyed consumable.',
+        },
+    },
+    config = {
+        extra = {
+            levels_per_consumable = 1,
+        },
+    },
+    rarity = 3,
+    atlas = 'Judgement',
+    pos = { x = 3, y = 1 },
+    cost = 10,
+    blueprint_compat = false,
+    perishable_compat = true,
+    eternal_compat = true,
+    calculate = function (self, card, context)
+        if not context.first_hand_drawn or context.blueprint then return end
+
+        local consumable_count = #G.consumeables.cards
+        if consumable_count == 0 then return end
+
+        for i = consumable_count, 1, -1 do
+            local consumable = G.consumeables.cards[i]
+            -- Should we also remove them from the consumable list already?
+            -- As it stands, two Event Horizons upgrade the hand twice.
+            consumable:start_dissolve({ G.C.RED })
+        end
+
+        local highest_played_count = 0
+        local highest_played_hands = {}
+        for k, v in pairs(G.GAME.hands) do
+            if v.played == highest_played_count then
+                highest_played_hands[#highest_played_hands+1] = k
+            elseif v.played > highest_played_count then
+                highest_played_count = v.played
+                highest_played_hands = { k }
+            end
+        end
+
+        local hand_to_upgrade = pseudorandom_element(highest_played_hands, pseudoseed('event_horizon'))
+        local levels = consumable_count * card.ability.extra.levels_per_consumable
+        delay(1)
+        perform_hand_levelup(hand_to_upgrade, levels)
+    end
+}

--- a/lovely/card_patches.toml
+++ b/lovely/card_patches.toml
@@ -1,0 +1,13 @@
+[manifest]
+version = '1.0.0'
+priority = -1
+
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+pattern = 'function Card:start_dissolve(dissolve_colours, silent, dissolve_time_fac, no_juice)'
+position = 'after'
+payload = '''
+self.is_dissolving = true
+'''
+match_indent = true

--- a/main.lua
+++ b/main.lua
@@ -64,6 +64,10 @@ if debug then
                     set = 'Joker',
                     key = 'j_jdg_bishop',
                 })
+                SMODS.add_card({
+                    set = 'Joker',
+                    key = 'j_jdg_traveller',
+                })
             end
 
             SMODS.add_card({

--- a/main.lua
+++ b/main.lua
@@ -18,6 +18,7 @@ local jokers_to_load = {
 
     -- Rare jokers
     'deal_with_the_devil',
+    'event_horizon',
 }
 
 for _, name in ipairs(jokers_to_load) do
@@ -58,12 +59,30 @@ if debug then
                     set = 'Joker',
                     key = 'j_blueprint',
                 })  
+                SMODS.add_card({
+                    set = 'Joker',
+                    key = 'j_jdg_bishop',
+                })
             end
 
             SMODS.add_card({
                 set = 'Joker',
-                key = 'j_jdg_bishop',
+                key = 'j_jdg_event_horizon',
             })
+        end
+    }
+
+    SMODS.Keybind {
+        key = 'make_consumable',
+        key_pressed = 'c',
+        held_keys = { 'lctrl' },
+        action = function ()
+            local card = SMODS.create_card({
+                set = 'Tarot',
+            })
+
+            card:add_to_deck()
+            G.consumeables:emplace(card)
         end
     }
 

--- a/main.lua
+++ b/main.lua
@@ -19,6 +19,7 @@ local jokers_to_load = {
 
     -- Rare jokers
     'deal_with_the_devil',
+    'event_horizon',
 }
 
 for _, name in ipairs(jokers_to_load) do
@@ -61,14 +62,32 @@ if debug then
                 })
                 SMODS.add_card({
                     set = 'Joker',
+                    key = 'j_jdg_bishop',
+                })
+                SMODS.add_card({
+                    set = 'Joker',
                     key = 'j_jdg_traveller'
                 })
             end
 
             SMODS.add_card({
                 set = 'Joker',
-                key = 'j_jdg_bishop',
+                key = 'j_jdg_event_horizon',
             })
+        end
+    }
+
+    SMODS.Keybind {
+        key = 'make_consumable',
+        key_pressed = 'c',
+        held_keys = { 'lctrl' },
+        action = function ()
+            local card = SMODS.create_card({
+                set = 'Tarot',
+            })
+
+            card:add_to_deck()
+            G.consumeables:emplace(card)
         end
     }
 


### PR DESCRIPTION
Before blind selection:
![Image showing two consumables and one Event Horizon joker](https://github.com/user-attachments/assets/729bcb65-e51f-47c9-840c-0bf87326e4fc)

Cards are deleted and hand is upgraded:
![Image showing consumables no longer there and the hand Straight Flush being upgraded two levels](https://github.com/user-attachments/assets/2f4c3a75-bfd2-4202-ae39-19ac64929167)

Upgrade table afterwards:
![Image showing the upgrade list with Straight Flush being the only hand that is level three](https://github.com/user-attachments/assets/ae683f87-b231-4b50-af0b-29d1317c8155)

Upgrade table afterwards with two consumables and two Event Horizons:
![Image showing the upgrade list with High Card being only level three, as expected](https://github.com/user-attachments/assets/b06eb54f-cb3f-49b5-9f19-4378bdc50473)
